### PR TITLE
feat(transactions): implement soft delete with deletion reason tracking

### DIFF
--- a/app/Filament/Resources/TransactionResource.php
+++ b/app/Filament/Resources/TransactionResource.php
@@ -505,6 +505,7 @@ class TransactionResource extends Resource
     public static function table(Table $table): Table
     {
         return $table
+            ->modifyQueryUsing(fn (Builder $query) => $query->whereNull('deleted_at'))
             ->columns([
                 Tables\Columns\TextColumn::make('transaction_number')
                     ->label('No. Transaksi')
@@ -910,7 +911,23 @@ class TransactionResource extends Resource
                         ->modalHeading('Hapus Transaksi')
                         ->modalDescription('Apakah Anda yakin ingin menghapus data transaksi ini?')
                         ->modalSubmitActionLabel('Ya, Hapus')
-                        ->modalCancelActionLabel('Batal'),
+                        ->modalCancelActionLabel('Batal')
+                        ->form([
+                            Forms\Components\Textarea::make('deletion_reason')
+                                ->label('Alasan Penghapusan')
+                                ->required()
+                                ->minLength(10)
+                                ->maxLength(500)
+                                ->placeholder('Masukkan alasan penghapusan transaksi')
+                                ->validationMessages([
+                                    'required' => 'Alasan penghapusan wajib diisi',
+                                    'min' => 'Alasan penghapusan minimal 10 karakter',
+                                    'max' => 'Alasan penghapusan maksimal 500 karakter',
+                                ])
+                        ])
+                        ->before(function (Transaction $record, array $data) {
+                            session(['deletion_reason' => $data['deletion_reason']]);
+                        }),
                 ])
                     ->dropdown()
                     ->button()

--- a/app/Models/DeletedTransaction.php
+++ b/app/Models/DeletedTransaction.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class DeletedTransaction extends Model
+{
+    protected $fillable = [
+        'original_id',
+        'transaction_number',
+        'user_id',
+        'vehicles_id',
+        'vehicle_type_id',
+        'license_plate',
+        'owner',
+        'usage_date',
+        'fuel_id',
+        'fuel_type_id',
+        'amount',
+        'volume',
+        'usage_description',
+        'fuel_receipt',
+        'invoice',
+        'balance_id',
+        'deleted_by',
+        'deletion_reason',
+        'deleted_at'
+    ];
+
+    protected $casts = [
+        'usage_date' => 'date',
+        'deleted_at' => 'datetime',
+        'amount' => 'decimal:2',
+        'volume' => 'decimal:2',
+    ];
+
+    public function deletedBy()
+    {
+        return $this->belongsTo(User::class, 'deleted_by');
+    }
+
+    public function vehicle()
+    {
+        return $this->belongsTo(Vehicle::class, 'vehicles_id');
+    }
+
+    public function vehicleType()
+    {
+        return $this->belongsTo(VehicleType::class);
+    }
+
+    public function fuel()
+    {
+        return $this->belongsTo(Fuel::class);
+    }
+
+    public function fuelType()
+    {
+        return $this->belongsTo(FuelType::class);
+    }
+
+    public function balance()
+    {
+        return $this->belongsTo(Balance::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -71,10 +71,16 @@ class Transaction extends Model
         parent::boot();
 
         static::creating(function ($transaction) {
-            // Use current timestamp instead of usage_date
             $now = Carbon::now();
             $transaction->transaction_number = static::generateTransactionNumber($now);
         });
+
+        // Hapus event listener yang memaksa force delete
+        // static::deleted(function ($transaction) {
+        //     if (!$transaction->isForceDeleting()) {
+        //         $transaction->forceDelete();
+        //     }
+        // });
     }
 
     protected static function generateTransactionNumber($date)

--- a/app/Observers/TransactionObserver.php
+++ b/app/Observers/TransactionObserver.php
@@ -3,8 +3,10 @@
 namespace App\Observers;
 
 use App\Models\Transaction;
+use App\Models\DeletedTransaction;
 use App\Models\Balance;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Auth;
 use Filament\Notifications\Notification;
 
 class TransactionObserver
@@ -62,6 +64,33 @@ class TransactionObserver
     public function deleting(Transaction $transaction)
     {
         DB::transaction(function () use ($transaction) {
+            // Get deletion reason from session
+            $deletionReason = session('deletion_reason');
+            session()->forget('deletion_reason');
+
+            // Save to deleted_transactions table
+            DeletedTransaction::create([
+                'original_id' => $transaction->id,
+                'transaction_number' => $transaction->transaction_number,
+                'user_id' => $transaction->user_id,
+                'vehicles_id' => $transaction->vehicles_id,
+                'vehicle_type_id' => $transaction->vehicle_type_id,
+                'license_plate' => $transaction->license_plate,
+                'owner' => $transaction->owner,
+                'usage_date' => $transaction->usage_date,
+                'fuel_id' => $transaction->fuel_id,
+                'fuel_type_id' => $transaction->fuel_type_id,
+                'amount' => $transaction->amount,
+                'volume' => $transaction->volume,
+                'usage_description' => $transaction->usage_description,
+                'fuel_receipt' => $transaction->fuel_receipt,
+                'invoice' => $transaction->invoice,
+                'balance_id' => $transaction->balance_id,
+                'deleted_by' => Auth::id(),
+                'deletion_reason' => $deletionReason,
+                'deleted_at' => now()
+            ]);
+
             // Restore balance
             $balance = Balance::find($transaction->balance_id);
             if ($balance) {
@@ -70,8 +99,11 @@ class TransactionObserver
                 $balance->save();
             }
 
-            // Set transaction_number to null
-            $transaction->forceFill(['transaction_number' => null])->save();
+            // Set transaction_number to null BEFORE the soft delete happens
+            $transaction->update(['transaction_number' => null]);
+
+            // Let the soft delete happen naturally
+            // No need to call forceDelete()
 
             // Trigger widget refresh
             broadcast(new \App\Events\TransactionCreated())->toOthers();

--- a/database/migrations/2024_01_16_000000_create_deleted_transactions_table.php
+++ b/database/migrations/2024_01_16_000000_create_deleted_transactions_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::create('deleted_transactions', function (Blueprint $table) {
+            $table->id();
+            $table->string('original_id');
+            $table->string('transaction_number')->nullable();
+            $table->foreignId('user_id')->constrained();
+            $table->foreignId('vehicles_id')->constrained();
+            $table->foreignId('vehicle_type_id')->constrained();
+            $table->string('license_plate');
+            $table->string('owner');
+            $table->date('usage_date');
+            $table->foreignId('fuel_id')->constrained();
+            $table->foreignId('fuel_type_id')->constrained();
+            $table->decimal('amount', 12, 2);
+            $table->decimal('volume', 8, 2);
+            $table->text('usage_description');
+            $table->string('fuel_receipt')->nullable();
+            $table->string('invoice')->nullable();
+            $table->foreignId('balance_id')->constrained();
+            $table->foreignId('deleted_by')->constrained('users');
+            $table->text('deletion_reason')->nullable();
+            $table->timestamp('deleted_at');
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('deleted_transactions');
+    }
+};


### PR DESCRIPTION
🇬🇧 English:
- Add deleted_transactions table to store deleted transaction history
- Implement deletion reason form before transaction deletion
- Store deleted transaction data with deletion reason and metadata
- Set transaction_number to null when transaction is deleted
- Keep transaction history while maintaining unique transaction numbers
- Add filters to show only active transactions in the list

🇮🇩 Indonesia:
- Menambahkan tabel deleted_transactions untuk menyimpan riwayat transaksi yang dihapus
- Menerapkan form alasan penghapusan sebelum transaksi dihapus
- Menyimpan data transaksi yang dihapus beserta alasan dan metadata
- Mengatur transaction_number menjadi null saat transaksi dihapus
- Menjaga riwayat transaksi sambil mempertahankan keunikan nomor transaksi
- Menambahkan filter untuk menampilkan hanya transaksi aktif dalam daftar